### PR TITLE
Community talks for the schedule

### DIFF
--- a/_schedule-day1/1100-1130-coffee.md
+++ b/_schedule-day1/1100-1130-coffee.md
@@ -4,5 +4,5 @@ to: "11:30"
 break: true
 title: Coffee Break by <a href="https://jobs.zalando.com/tech/">Zalando</a>
 speaker:
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+details: 🌩 Lightning Talks in the <a href="http://mozillahu.github.io/hackerlounge/#lightning-talks">Mozilla Hackerlounge</a> and the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge
 ---

--- a/_schedule-day1/1230-1430-lunch.md
+++ b/_schedule-day1/1230-1430-lunch.md
@@ -2,6 +2,15 @@
 from: "12:30"
 to: "14:30"
 break: true
-title: Lunch 
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+title: Lunch
+details: |
+  Enjoy your lunch while watching fun & inspiring talks, discussions and trying exciting/futuristic demos, all made with web technologies!
+  <ul>
+    <li>12:45 – Community talk in the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge:
+      <blockquote>Eva Lettner – The Magic of CSS</blockquote></li>
+    <li>13:30 – Discussion panel in the <a href="http://mozillahu.github.io/hackerlounge/">Mozilla Hackerlounge</a>:
+      <blockquote><a href="http://mozillahu.github.io/hackerlounge/#discussion-on-public-speaking-and-conferences">On Public Speaking & Conferences 🎙</a>
+        <br>with Dan Callahan, Madeleine Neumann, Kevin Lorenz & more.
+      </blockquote></li>
+  </ul>
 ---

--- a/_schedule-day1/1600-1630-coffee.md
+++ b/_schedule-day1/1600-1630-coffee.md
@@ -4,6 +4,6 @@ to: "16:30"
 break: true
 title: Coffee Break by <a href="https://jobs.zalando.com/tech/">Zalando</a>
 speaker:
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+details: Speaker Q &amp; A in the <a href="http://mozillahu.github.io/hackerlounge/#lightning-talks">Mozilla Hackerlounge</a> and in the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge
 
 ---

--- a/_schedule-day1/1800-2000-dinner.md
+++ b/_schedule-day1/1800-2000-dinner.md
@@ -3,9 +3,9 @@ from: "18:00"
 to: "20:00"
 break: true
 title: Dinner
-sponsor: 
+sponsor:
 address:
 url:
 speaker:
-
+details: Speaker Q &amp; A, WebVR & Servo demos in the <a href="http://mozillahu.github.io/hackerlounge/#lightning-talks">Mozilla Hackerlounge</a>
 ---

--- a/_schedule-day2/1100-1130-coffee.md
+++ b/_schedule-day2/1100-1130-coffee.md
@@ -4,5 +4,5 @@ to: "11:30"
 break: true
 title: Coffee Break by <a href="https://jobs.zalando.com/tech/">Zalando</a>
 speaker:
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+details: 🌩 Lightning Talks in the <a href="http://mozillahu.github.io/hackerlounge/#lightning-talks">Mozilla Hackerlounge</a> and the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge
 ---

--- a/_schedule-day2/1230-1430-lunch.md
+++ b/_schedule-day2/1230-1430-lunch.md
@@ -4,5 +4,14 @@ to: "14:30"
 break: true
 title: Lunch
 speaker:
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+details: |
+  Enjoy your lunch while watching fun & inspiring talks, discussions and trying exciting/futuristic demos, all made with web technologies!
+  <ul>
+    <li>12:45 – Community talk in the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge:
+      <blockquote>Lisa Passing – Making Web API Games</blockquote></li>
+    <li>13:30 – Discussion panel in the <a href="http://mozillahu.github.io/hackerlounge/">Mozilla Hackerlounge</a>:
+      <blockquote><a href="http://mozillahu.github.io/hackerlounge/#discussion-teach-and-learn-the-web">On Teaching &amp; Learning New Skills 📚</a>
+        <br>with teachers &amp; mentors from around the world.
+      </blockquote></li>
+  </ul>
 ---

--- a/_schedule-day2/1600-1630-coffee.md
+++ b/_schedule-day2/1600-1630-coffee.md
@@ -4,5 +4,5 @@ to: "16:30"
 break: true
 title: Coffee Break by <a href="https://jobs.zalando.com/tech/">Zalando</a>
 speaker:
-details: Community talks by <a href="https://www.mozilla.org/">Mozilla</a> and <a href="https://jobs.zalando.com/tech/">Zalando</a>
+details: Speaker Q &amp; A in the <a href="http://mozillahu.github.io/hackerlounge/#lightning-talks">Mozilla Hackerlounge</a> and in the <a href="https://jobs.zalando.com/tech/">Zalando</a> lounge
 ---


### PR DESCRIPTION
Here is a more precise/detailed version of the "community track" for the website schedule. It may need a slight CSS touchup and I haven't yet pushed the page live that the Hackerlounge links link to but should give you a broad idea of how this will work.

To view just check out the PR branch locally. :)
_(tried popping this [into gh pages](https://flaki.github.io/2017.jsconfbp.com/schedule_pre), but turns out site isn't very well-behaved once it is served from a subdir haha :D )_